### PR TITLE
Update README.md - launch instructions missing required argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This project uses the database connections feature of Static Web Apps to provide
 1. Clone this repository
 2. Navigate to `library` directory & open with VSCode
 3. Set the `DATABASE_CONNECTION_STRING` environment variable to your connection string in your terminal/cmd/powershell. Alternatively, paste your database connection string directly into `swa-db-connections/staticwebapp.database.config.json` (*not recommended*) (ensure that you remove this secret from your source code before pushing to GitHub/remote repository)
-4. Run `swa start http://localhost:3000 --run "cd library-demo && npm i && npm start" swa-db-connections`
+4. Run `swa start http://localhost:3000 --run "cd library-demo && npm i && npm start" --data-api-location swa-db-connections`
     * `cd library-demo && npm i && npm start` will install needed npm packages and run your React app
     * `--data-api-location swa-db-connections` indicates to the SWA CLI that your database connections configurations are in the `swa-db-connections` folder
 Alternatively, you can start all these projects manually an make use of SWA CLI's other args


### PR DESCRIPTION
Added missing --data-api-location parameter name to "To get started locally" point 4.

Was: swa start http://localhost:3000 --run "cd library-demo && npm i && npm start" swa-db-connections

Now: swa start http://localhost:3000 --run "cd library-demo && npm i && npm start" --data-api-location swa-db-connections

## Purpose
The "To get started locally" section of the README.md page shows an incomplete command line to launch the Static Web App locally. In this PR, I've added back in the required missing parameter name "--data-api-location". Without this, the app will build and launch without a data-api endpoint. When the browser attempts to hit the /data-api endpoint, the SWA terminates with a SIGTERM.

## Does this introduce a breaking change?
No. Although without this key piece of information, you get very different behaviour.
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
* Get the code
* Try running the old command line:
```
swa start http://localhost:3000 --run "cd library-demo && npm i && npm start" swa-db-connections
```
* Observe it dying like a proverbial:
![image](https://user-images.githubusercontent.com/20968935/233824376-1079d923-cb22-43ab-9d1d-e9528bf5d22d.png)
* Cry a little inside for several hours while you try to figure out why this example doesn't work, when apparently I'd managed to avoid the typo when trying this repo out *on a different VM*. 😢
* Cry even more when you realise you've wasted all this time on a typo. 😭
* Try running the new command line:
```
swa start http://localhost:3000 --run "cd library-demo && npm i && npm start" --data-api-location swa-db-connections
```
* Observe it works.
* Cry a little bit more at all the wasted time. 😭

## Other Information
If you miss out the --data-api-location parameter name, you eventually get this error message:
```
[swa] GET http://localhost:3000/ (proxy)
[swa] GET http://localhost:4280/ - 200
[swa] GET http://localhost:3000/static/js/bundle.js (proxy)
[swa] GET http://localhost:4280/static/js/bundle.js - 200
[swa] node "/mnt/c/ProgramData/nvm/v16.18.1/node_modules/@azure/static-web-apps-cli/dist/msha/server.js" exited with code 0
--> Sending SIGTERM to other processes..
[run] cd "/home/joel/repos/dab-swa-library-demo" && cd library-demo && npm i && npm start exited with code SIGTERM
✖ SWA emulator stoped because the --run command exited with code SIGTERM.
```

It's pretty opaque. Hopefully this page will help someone if it gets indexed by Google at some point in the future.

¯\\_(ツ)_/¯