### PR TITLE
Updated readme metadata to fix bug with publishing to Microsoft Learn…

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ products:
 - azure
 - static-web-apps
 - azure-sql-database
-- data-api-builder
 urlFragment: sample
 name: Jamstack Library App with Azure Static Web Apps, Data API builder, and Azure SQL Database
 description: This sample uses the database connections feature of Azure Static Web Apps to provide CRUD access to database contents with REST, built-in authorizations, and support for database relationships with GraphQL.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ languages:
 - azstatic-cli
 - nodejs
 - javascript
+- data-api-builder
 products:
 - azure
 - static-web-apps


### PR DESCRIPTION
- [x] Modifies #9

There's a bug with publishing where `data-api-builder` is not a valid value for `products`. It's a valid value for `languages` instead.

<https://github.com/MicrosoftDocs/samples/blob/main/Azure-Samples/dab-swa-library-demo/.samples-status.json#L10>